### PR TITLE
Transform scrollable slider into dynamic grid

### DIFF
--- a/src/components/Card/Card.scss
+++ b/src/components/Card/Card.scss
@@ -3,7 +3,7 @@
 
 .card {
   background-color: $white;
-  min-width: 16rem;
+  max-width: 16rem;
   padding-top: 16rem;
   position: relative;
   overflow: hidden;

--- a/src/components/CardList/CardList.scss
+++ b/src/components/CardList/CardList.scss
@@ -3,18 +3,32 @@
 
 .card-list {
   display: flex;
-  overflow-x: scroll;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+  margin: auto;
   padding: 2rem;
 
-  .card:not(:first-child) {
-    margin-left: 0.8rem;
+  @include sm-up {
+    gap: 1rem;
+  }
+
+  @include md-up {
+    gap: 1.5rem;
+  }
+
+  .card {
+    flex-basis: 100%;
 
     @include sm-up {
-      margin-left: 1rem;
+      flex-basis: 50%;
     }
 
     @include md-up {
-      margin-left: 1.5rem;
+      flex-basis: calc(100% / 3);
+    }
+
+    @include lg-up {
+      flex-basis: 25%;
     }
   }
 }


### PR DESCRIPTION
Due to the large amount of items, the previous slider has become a grid that shows 1, 2, 3 or 4 columns depending on the viewport size.