### PR TITLE
Increase Contenful api response limit

### DIFF
--- a/src/pages/Home/Home.js
+++ b/src/pages/Home/Home.js
@@ -26,6 +26,7 @@ function Home() {
   useEffect(() => {
     client.getEntries({
       content_type: 'product',
+      limit: 300,
     }).then(((response) => {
       setProducts(response.items.sort((a, b) => a.fields.name.localeCompare(b.fields.name)));
     }));


### PR DESCRIPTION
By default, the API retrieves 100 elements, now that we have more than 100 entries 😵 it's necessary to increase this limit to receive all the products.